### PR TITLE
WIP: Efficient external file watching

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Add the following configuration to `tsconfig.json`. See [Available options](#ava
     "plugins": [
       {
         "name": "@mizdra/typescript-plugin-asset",
-        "include": ["assets/**/*"],
         "extensions": [".png", ".jpg", ".svg"],
         "exportedNameCase": "constantCase",
         "exportedNamePrefix": "I_"
@@ -72,17 +71,6 @@ Also, although this is optional, the following settings can be added to `.vscode
 ```
 
 ## Available options
-
-### `include` (required)
-
-Glob pattern of assets. `@mizdra/typescript-plugin-asset` completes import statements only for assets matching this pattern.
-
-- Type: `string[]`
-- Example: `["assets/**/*"]`
-
-### `exclude`
-
-Glob pattern of assets to exclude. `@mizdra/typescript-plugin-asset` does not complete import statements for assets matching this pattern.
 
 ### `extensions` (required)
 

--- a/examples/nextjs/package-lock.json
+++ b/examples/nextjs/package-lock.json
@@ -14,8 +14,10 @@
         "@types/react-dom": "18.2.4",
         "next": "13.4.1",
         "react": "18.2.0",
-        "react-dom": "18.2.0",
-        "typescript": "^4.9.4"
+        "react-dom": "18.2.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.3.0-dev.20231014"
       }
     },
     "../..": {
@@ -464,15 +466,16 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.3.0-dev.20231014",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.0-dev.20231014.tgz",
+      "integrity": "sha512-GdNly6XgR/4j8jLzjrs4OWRLomjRlBo/0oWtG1WA25VVHKWO6cd0CbfLNuII7LATW/KEvMBJg2sgpZosKejr9g==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/zod": {
@@ -735,9 +738,10 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
+      "version": "5.3.0-dev.20231014",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.0-dev.20231014.tgz",
+      "integrity": "sha512-GdNly6XgR/4j8jLzjrs4OWRLomjRlBo/0oWtG1WA25VVHKWO6cd0CbfLNuII7LATW/KEvMBJg2sgpZosKejr9g==",
+      "dev": true
     },
     "zod": {
       "version": "3.21.4",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -17,7 +17,9 @@
     "@types/react-dom": "18.2.4",
     "next": "13.4.1",
     "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "typescript": "^4.9.4"
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.0-dev.20231014"
   }
 }

--- a/examples/nextjs/tsconfig.json
+++ b/examples/nextjs/tsconfig.json
@@ -18,7 +18,6 @@
       { "name": "next" },
       {
         "name": "@mizdra/typescript-plugin-asset",
-        "include": ["assets/**/*"],
         "extensions": [".png", ".jpg", ".svg"],
         "exportedNameCase": "constantCase",
         "exportedNamePrefix": "I_"

--- a/src/language-service-host.ts
+++ b/src/language-service-host.ts
@@ -1,11 +1,8 @@
 import path from 'node:path';
-import { createVirtualFiles } from '@volar/language-core';
-import { decorateLanguageServiceHost as _decorateLanguageServiceHost } from '@volar/typescript';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import { AssetPluginOptions, SuggestionRule } from './option';
 
 export type AssetLanguageServiceHost = {
-  getAssetFileNames(): string[];
   isAssetFile(filePath: string): boolean;
   getMatchedSuggestionRule(assetFilePath: string): SuggestionRule | undefined;
 };
@@ -15,80 +12,16 @@ export function createAssetLanguageServiceHost(
   info: ts.server.PluginCreateInfo,
   assetPluginOptions: AssetPluginOptions,
 ): AssetLanguageServiceHost {
-  if (sys.watchDirectory === undefined) throw new Error('sys.watchDirectory is undefined');
-
-  const projectRoot = path.dirname(assetPluginOptions.tsConfigPath);
-
-  function isMatchFile(fileName: string, extensions: string[], exclude: string[], include: string[]): boolean {
-    if (!extensions.includes(path.extname(fileName))) return false;
-    return sys.readDirectory(path.dirname(fileName), extensions, exclude, include, 1).includes(fileName);
-  }
-  function getAssetFileNameAndRule(): Map<string, SuggestionRule> {
-    const assetFileNameAndRule = new Map<string, SuggestionRule>();
-    const fileNames = sys.readDirectory(
-      path.dirname(assetPluginOptions.tsConfigPath),
-      assetPluginOptions.extensions,
-      assetPluginOptions.exclude,
-      assetPluginOptions.include,
-    );
-    for (const fileName of fileNames) {
+  return {
+    isAssetFile(filePath: string) {
+      return assetPluginOptions.extensions.includes(path.extname(filePath));
+    },
+    getMatchedSuggestionRule(_assetFilePath: string) {
       // TODO: support custom rule
-      assetFileNameAndRule.set(fileName, {
+      return {
         exportedNameCase: assetPluginOptions.exportedNameCase,
         exportedNamePrefix: assetPluginOptions.exportedNamePrefix,
-      });
-    }
-    return assetFileNameAndRule;
-  }
-
-  const assetFileNameAndRule = getAssetFileNameAndRule();
-  sys.watchDirectory(
-    projectRoot,
-    (fileName) => {
-      if (!isMatchFile(fileName, assetPluginOptions.extensions, assetPluginOptions.exclude, assetPluginOptions.include))
-        return;
-      if (sys.fileExists(fileName)) {
-        // TODO: support custom rule
-        assetFileNameAndRule.set(fileName, {
-          exportedNameCase: assetPluginOptions.exportedNameCase,
-          exportedNamePrefix: assetPluginOptions.exportedNamePrefix,
-        });
-      } else {
-        assetFileNameAndRule.delete(fileName);
-      }
-      info.project.markAsDirty();
-      info.project.updateGraph();
+      };
     },
-    true,
-    { excludeDirectories: assetPluginOptions.exclude },
-  );
-
-  return {
-    getAssetFileNames() {
-      return [...assetFileNameAndRule.keys()];
-    },
-    isAssetFile(filePath: string) {
-      return assetFileNameAndRule.has(filePath);
-    },
-    getMatchedSuggestionRule(assetFilePath: string) {
-      return assetFileNameAndRule.get(assetFilePath);
-    },
-  };
-}
-
-// eslint-disable-next-line max-params
-export function decorateLanguageServiceHost(
-  assetLanguageServiceHost: AssetLanguageServiceHost,
-  project: ts.server.Project,
-  virtualFiles: ReturnType<typeof createVirtualFiles>,
-  languageServiceHost: ts.LanguageServiceHost,
-  ts: typeof import('typescript/lib/tsserverlibrary'),
-  extensions: string[],
-) {
-  _decorateLanguageServiceHost(virtualFiles, languageServiceHost, ts, extensions);
-
-  const getScriptFileNames = project.getScriptFileNames.bind(project);
-  languageServiceHost.getScriptFileNames = () => {
-    return [...getScriptFileNames(), ...assetLanguageServiceHost.getAssetFileNames()];
   };
 }


### PR DESCRIPTION
ref: https://github.com/vuejs/language-tools/pull/3649, https://github.com/microsoft/TypeScript/pull/56047

Until now, it was not possible to watch asset file additions with tsserver alone. Therefore, typescript-plugin-asset used `ts.sys.watchDirectory` to watch asset file additions on its own.

Normally, watching the file system is expensive. Therefore, it is not a good idea for both tsserver and plugin to watch the file system. Only one of them should do the watching.

In this PR, watching the asset files is also left to the tsserver side and the watching in the plugin is removed.
